### PR TITLE
Poster sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Enter a (valid) Spotify album URL, receive a poster!
 [Example Images](https://imgur.com/a/js908oH)!
 
 ### Issues/Ideas
-- [ ] Choose poster size
 - [ ] Tracks vertical length scaling
 - [ ] Drop down menu in main webpage to search for album
   
 ### Fixed Issues 🎉
+- [x] Choose poster size
 - [x] Special characters not supported
 - [x] Better font
-- [X] No checking for validity of URL
+- [x] No checking for validity of URL
 ---
 
 You'll need a .env file with the following values:

--- a/poster_generator.py
+++ b/poster_generator.py
@@ -125,7 +125,8 @@ def generator(album, resolution) -> ImageDraw:
     #
     playtime_font_size = int(album_font_size//1.5)
     playtime_font = ImageFont.truetype(fonts['source-code-pro.light.ttf'], playtime_font_size)
-    poster_draw.text((resolution[0] - spacing - playtime_font.getbbox(data['playtime'])[2], y_position), data['playtime'], (0,0,0), font=playtime_font)
+    playtime_y_position = y_position + int(artist_font.size/2.25) - playtime_font.size  # align playtime with bottom of album name instead of top
+    poster_draw.text((resolution[0] - spacing - playtime_font.getbbox(data['playtime'])[2], playtime_y_position), data['playtime'], (0,0,0), font=playtime_font)
 
     y_position += 2*spacing
 

--- a/templates/mainpage.html
+++ b/templates/mainpage.html
@@ -4,6 +4,7 @@
         <title>Poster Generator</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+        <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
         <link href="{{ url_for('static', filename='main.css') }}" rel="stylesheet">
         <meta charset="UTF-8">
     </head>
@@ -13,9 +14,12 @@
             <h1>Spotify Poster Generator</h1>
         </div>
 
-        <form class="form-group container" method="POST" action="/result" autocomplete="off" onsubmit="removeNotification()">
+        <form id="form" class="form-group container" method="POST" action="/result" autocomplete="off" onsubmit="removeNotification()">
             <input class="form-control input-field" type="text" id="album_link" name="album_input" placeholder="Enter Spotify Album Link">
             <input class="form-control btn btn-outline-light submit-button" type="submit" value="Submit">
+
+            <input type="hidden" id="hidden_width_input" name="width">
+            <input type="hidden" id="hidden_height_input" name="height">
         </form>
 
         {% if warning_notification %}
@@ -24,12 +28,82 @@
             </div>
         {% endif %}
 
+        <div id="accordion" class="card">
+            <div class="card-header" id="heading">
+                <button class="btn" data-bs-toggle="collapse" data-bs-target="#collapse_advanced_options" aria-expanded="true" aria-controls="collapseAdvancedOptions">
+                    Advanced options
+                </button>
+            </div>
+            <div id="collapse_advanced_options" class="collapse" aria-labelledby="heading" data-bs-parent="#accordion">
+                <div class="card-body" style="text-align: start">
+                    <div class="d-inline-flex align-items-baseline pb-2">
+                        <label for="select_format" class="pe-2"><b>Format:</b></label>
+                        <select id="select_format" class="form-select" aria-label="Default select example" onload="setSizeInput()" onchange="setSizeInput()">
+                            <option value="2480,3508">A4 (300 ppi)</option>
+                            <option value="1240,1754" selected>A4 (150 ppi)</option>
+                            <option value="2551,3295">US Letter (300 ppi)</option>
+                            <option value="1276,1648">US Letter (150 ppi)</option>
+                            <option value="custom">Custom</option>
+                        </select>
+                    </div>
+
+                    <div class="d-inline-flex align-items-baseline">
+                        <label for="width_input" class="pe-2"><b>Size:</b></label>
+                        <div class="input-group mb-3">
+                            <input id="width_input" class="form-control" aria-label="Width in pixel" readonly type="number">
+                            <div class="input-group-append">
+                                <span class="input-group-text">px</span>
+                            </div>
+                        </div>
+                        <p class="ps-2 pe-2">X</p>
+                        <div class="input-group mb-3">
+                            <input id="height_input" class="form-control" aria-label="Height in pixel" readonly type="number">
+                            <div class="input-group-append">
+                                <span class="input-group-text">px</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <script>
             function removeNotification() {
                 const notificationElement = document.getElementById('notification');
                 if (notificationElement)
                     notificationElement.remove();
             }
+
+            function setSizeInput() {
+                const selectedValue = document.getElementById('select_format').value;
+                if (selectedValue === 'custom') {
+                    document.getElementById('width_input').readOnly = false;
+                    document.getElementById('height_input').readOnly = false;
+                }
+                else {
+                    const size = selectedValue.split(',');
+                    document.getElementById('width_input').value = parseInt(size[0]);
+                    document.getElementById('width_input').readOnly = true;
+                    document.getElementById('height_input').value = parseInt(size[1]);
+                    document.getElementById('height_input').readOnly = true;
+                }
+            }
+
+            setSizeInput() // trigger on load
+
+            document.getElementById('form').addEventListener('submit', function(e) {
+                e.preventDefault(); // Prevent default form submission
+
+                // Get values from the external input fields
+                const width = document.getElementById('width_input').value;
+                const height = document.getElementById('height_input').value;
+
+                // Update the values of the hidden input fields
+                document.getElementById('hidden_width_input').value = parseInt(width);
+                document.getElementById('hidden_height_input').value = parseInt(height);
+
+                document.getElementById('form').submit();
+            });
         </script>
     </body>
 </html>

--- a/utils.py
+++ b/utils.py
@@ -34,7 +34,10 @@ def spotify_data_pull(album):
     if album_url_base not in album:
         return None
 
-    album = album[:album.find('?')]
+    # remove query parameters if present
+    if '?' in album:
+        album = album[:album.find('?')]
+
     id = album[album.find(album_url_base)+len(album_url_base):]
 
     auth_response = requests.post(AUTH_URL, {

--- a/webapp.py
+++ b/webapp.py
@@ -8,11 +8,9 @@
     You should have received a copy of the GNU General Public License along with poster-gen. If not, see <https://www.gnu.org/licenses/>.
 """
 
-from flask import Flask, render_template, request, send_file
+from flask import Flask, render_template, request, send_file, redirect
 from poster_generator import generator
-from PIL import Image
 import io
-from base64 import b64encode
 from dotenv import load_dotenv
 import os
 
@@ -31,18 +29,20 @@ def index():
 def result():
     if request.method == 'POST':
         album_link = request.form["album_input"]
+        width = 3300 if 'width' not in request.form else int(request.form["width"])
+        height = 5100 if 'height' not in request.form else int(request.form["height"])
 
         # check that input is not empty
-        if album_link == "":
+        if album_link == "" or album_link is None:
             return render_template('mainpage.html', warning_notification='Input field cannot be empty')
 
         # generate poster
-        poster, album_name = generator(album_link, (3300, 5100))
+        poster, album_name = generator(album_link, (width, height))
 
         # check that album data was fetched
         if poster is None or album_name is None:
             return render_template('mainpage.html', warning_notification=f'Failed to get album data based on input "{album_link}"')
-        
+
         poster_bytes = io.BytesIO()
         poster.save(poster_bytes, "png")
         poster_bytes.seek(0)
@@ -53,6 +53,10 @@ def result():
             download_name="{}_poster.jpg".format(album_name),
             as_attachment=True
         )
+
+    else:
+        # redirect to home screen if result page is called in browser
+        return redirect('/')
 
 
 if __name__ == '__main__':

--- a/webapp.py
+++ b/webapp.py
@@ -29,12 +29,18 @@ def index():
 def result():
     if request.method == 'POST':
         album_link = request.form["album_input"]
-        width = 3300 if 'width' not in request.form else int(request.form["width"])
-        height = 5100 if 'height' not in request.form else int(request.form["height"])
+        width = 3300 if 'width' not in request.form or not request.form["width"].isnumeric() else int(request.form["width"])
+        height = 5100 if 'height' not in request.form or not request.form["height"].isnumeric() else int(request.form["height"])
 
         # check that input is not empty
         if album_link == "" or album_link is None:
             return render_template('mainpage.html', warning_notification='Input field cannot be empty')
+
+        # check values for height and width
+        if width < 300 or height < 450:  # width and height have minimum requirements
+            return render_template('mainpage.html', warning_notification='Width must be at least 300px and height must be at least 450px')
+        if height < width * 1.25 or height > width * 2:  # height must be between 30% and 100% larger than width
+            return render_template('mainpage.html', warning_notification='Height must be between 25% and 100% larger than width')
 
         # generate poster
         poster, album_name = generator(album_link, (width, height))


### PR DESCRIPTION
- changed all measurements for processing to relative units
- added advanced options section in frontend to select the poster size
- did NOT change anything with the text of the songs

Note: Default paper sizes are more square (less high compared to width) than 5100x3300 which is why the height of the album cover is now limited to 60% of the entire poster